### PR TITLE
Use GNU standard for building under Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     name="etcpak",
     description="python wrapper for etcpak",
     author="K0lb3",
-    version="0.9.5",
+    version="0.9.6",
     keywords=["etc", "dxt", "texture", "python-c"],
     classifiers=[
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
             ],
             language="c++",
             include_dirs=["src/etcpak"],
-            extra_compile_args=["-std=c++11"] + (
+            extra_compile_args=["-std=gnu++11"] + (
                 ["-Wno-c++11-narrowing","-Wc++11-narrowing"] if platform.system() == "Darwin" else []
             ),
         )


### PR DESCRIPTION
It may seem counter-intuitive, but on MSys2, `fileno()` can only be used when using the GNU compiler standard. Otherwise the build will fail.