### PR TITLE
support build in msys2

### DIFF
--- a/src/etcpak/BlockData.cpp
+++ b/src/etcpak/BlockData.cpp
@@ -30,6 +30,9 @@
 //#  define bswap_16(x) OSSwapInt16(x)
 #  define _bswap(x) OSSwapInt32(x)
 #  define _bswap64(x) OSSwapInt64(x)
+#elif defined(__MINGW32__)
+#    include <intrin.h>
+#    include <Windows.h>
 #else
 #  ifndef _MSC_VER
 #    include <byteswap.h>

--- a/src/etcpak/ProcessRGB.cpp
+++ b/src/etcpak/ProcessRGB.cpp
@@ -27,6 +27,9 @@
 //#  define bswap_16(x) OSSwapInt16(x)
 #  define _bswap(x) OSSwapInt32(x)
 #  define _bswap64(x) OSSwapInt64(x)
+#elif defined(__MINGW32__)
+#    include <intrin.h>
+#    include <Windows.h>
 #else
 #  ifndef _MSC_VER
 #    include <byteswap.h>


### PR DESCRIPTION
only build test in [msys2/mingw64](https://github.com/msys2/MINGW-packages),in theory [msys2/mingw32](https://github.com/msys2/MINGW-packages) or [mingw64](https://sourceforge.net/projects/mingw-w64/) can also be successfully build.

this will allow install UnityPy in msys2/mingw,like this:
```shell
#in msys2/mingw64 shell
pacman -S mingw-w64-x86_64-python mingw-w64-x86_64-python-pip
pip3 install UnityPy
```

[msys2 packages](https://github.com/msys2/MSYS2-packages) don't exist libjepg,can't install Pillow,need manual build it.