### PR TITLE
sdist missing header file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,7 @@ setup(
                 # Mac fix due to .c problem
                 "-DBCDEC_IMPLEMENTATION=1",
             ],
+            depends=["src/etcpak/bc7enc.h","src/etcpak/bcdec.h","src/etcpak/lz4/lz4.h"]
         )
     ],
     cmdclass={"build_ext": CustomBuildExt},


### PR DESCRIPTION
`python setup.py sdist` output tar.gz contain no .h for C language.

depends argument allow add custom file.