### PR TITLE
Texture2DConverter image_to_texture2d compression fix BC7

### DIFF
--- a/src/pylink.cpp
+++ b/src/pylink.cpp
@@ -90,7 +90,7 @@ static PyObject *compress_bc7(PyObject *self, PyObject *args)
 
     // compress
     bc7enc_compress_block_init();
-    if (params == nullptr)
+    if (params == Py_None || params == nullptr)
     {
         bc7enc_compress_block_params bc7params;
         bc7enc_compress_block_params_init(&bc7params);


### PR DESCRIPTION
Suggested fix for K0lb3/UnityPy#330 where UnityPy couldn't save a new image for a texture2D